### PR TITLE
Groups API 에러핸들링

### DIFF
--- a/pages/api/groups/index.ts
+++ b/pages/api/groups/index.ts
@@ -41,7 +41,6 @@ const groupHandler = async (req: NextApiRequest, res: NextApiResponse) => {
 
         if (documents.length !== 0) {
           res.status(422).json({ message: '동일한 문장집이 존재합니다.' });
-          client.close();
           return;
         }
 


### PR DESCRIPTION
## Description
문장집 등록시 동일한 이름 존재할때 알림메세지 오류 수정

## Changes
- groups api의 post api 수정
  - client.close 삭제 (중복으로 인한 405 status 발생)