### PR TITLE
문장집 이름변경 api 오류 수정

### DIFF
--- a/components/modals/GroupNameModal.tsx
+++ b/components/modals/GroupNameModal.tsx
@@ -56,7 +56,7 @@ const GroupNameModal = ({
   const changeGroupName = (value: GroupProps) => {
     const { name } = value;
 
-    changeName({ name, groupId: selectGroupId });
+    changeName({ name, groupId: selectGroupId, email: user.email });
 
     hideModal();
     setContext('');

--- a/pages/api/groups/actions/change-name.ts
+++ b/pages/api/groups/actions/change-name.ts
@@ -4,15 +4,14 @@ import { ObjectId } from 'mongodb';
 import { dbConnect, getAllDocuments, updateDocument } from '@lib/db';
 
 const changeGroupName = async (req: NextApiRequest, res: NextApiResponse) => {
-  const { name, groupId } = req.body;
+  const { name, groupId, email } = req.body;
   const client = await dbConnect();
 
   try {
-    const documents = await getAllDocuments(client, 'groups', { name });
+    const documents = await getAllDocuments(client, 'groups', { name, email });
 
     if (documents.length !== 0) {
       res.status(422).json({ message: '동일한 문장집이 존재합니다.' });
-      client.close();
       return;
     }
 

--- a/react-query/hooks/group/useChangeGroupName.ts
+++ b/react-query/hooks/group/useChangeGroupName.ts
@@ -11,12 +11,14 @@ import { useCustomToast } from '@hooks/useCustomToast';
 type NewGroupName = {
   name: string;
   groupId: string | undefined;
+  email: string;
 };
 
 const setGroupName = async (newGroupNameData: NewGroupName) => {
-  await axios.patch(`api/groups/actions/change-name`, {
+  await axios.patch(`/api/groups/actions/change-name`, {
     name: newGroupNameData.name,
     groupId: newGroupNameData.groupId,
+    email: newGroupNameData.email,
   });
 };
 


### PR DESCRIPTION
## Description
문장집 이름 변경 api 오류 수정
  - 문장집 이름 변경시 DB내 다른 유저의 같은 문장집 이름 존재시 오류 발생

## Changes
- change-name api 에서 email 추가
- GroupNameModal에 email 추가
- react query hook 인 useChangeGroupName에서 axios 코드 변경 (body에 email 추가)
